### PR TITLE
pin to older r-spatial-base container with R-lang 3.3.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM achubaty/r-spatial-base
+FROM tesera/r-spatial-base:3.3.3
 
 RUN apt-get update
 


### PR DESCRIPTION
Some internal stuff to forest tools didn't run on R 3.4 so pinned this to R 3.3.3 for now.
Specifically crashed with no error at this line:  https://github.com/AndyPL22/ForestTools/blob/master/R/SegmentCrowns.R#L143