### PR TITLE
check for even sides in focal() matrix

### DIFF
--- a/R/vwf.R
+++ b/R/vwf.R
@@ -112,8 +112,9 @@ vwf <- function(CHM, winFun, minHeight = NULL, maxWinDiameter = 99, minWinNeib =
     }
 
     # Calculate the dimensions of the largest matrix to be created from the generated list of radii
-    maxDimension <- (max(radii) / roundRes[1]) * 2 + 1
-
+    maxDimension <- ceiling((max(radii) / roundRes[1]) * 2 + 1)
+    if (maxDimension %% 2 == 0) {maxDimension <- maxDimension + 1}
+  
     # Check if input formula will yield a window size bigger than the maximum set by 'maxWinDiameter'
     if(!is.null(maxWinDiameter) && maxDimension > maxWinDiameter){
 


### PR DESCRIPTION
It is currently possible to pass an even-sided matrix to the `raster::focal()` function, which throws an error.

The non-integer `maxDimension` object is used in the creation of the matrix passed to the `raster::focal()` function when creating the `lm.pts` object at the end of the `ForestTools::vwf()` function. Creating the `w` matrix using the `matrix()` function with non-integer values for the `nrow=` and `ncol=` arguments can result in a matrix with even dimensions, which throws a "w must have uneven sides" error when passed to the `raster::focal()` function (see line 74: https://github.com/cran/raster/blob/3e33743a12d2c8f407a4afc45dabc9ae9b1ae5fe/R/focal.R).

This patch uses the `ceiling()` function to ensure that `maxDimension` is an integer, then increments it by 1 if it is an even value (assessed using `maxDimension %% 2`).